### PR TITLE
change edge dependency type and switch to edge 1.0.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Build Failed :x:",
+                    "text": "AEPAnalyticsEdge [Android] -> Build Failed :x:",
                     "emoji": true
                   }
                 },
@@ -101,7 +101,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Build Successful :tada:",
+                    "text": "AEPAnalyticsEdge [Android] -> Build Successful :tada:",
                     "emoji": true
                   }
                 },

--- a/code/aepanalyticstestapp/build.gradle
+++ b/code/aepanalyticstestapp/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.adobe.marketing.aepanalyticstestapp"
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
@@ -45,6 +45,6 @@ dependencies {
     implementation "com.adobe.marketing.mobile:core:${rootProject.mavenCoreVersion}"
     implementation "com.adobe.marketing.mobile:identity:+"
     implementation "com.adobe.marketing.mobile:assurance:+"
-    implementation 'com.adobe.marketing.mobile:edge:1.0.0-beta-1'
+    implementation "com.adobe.marketing.mobile:edge:1.0.0"
     implementation project(':analyticsedge')
 }

--- a/code/analyticsedge/build.gradle
+++ b/code/analyticsedge/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0.0-beta-2"
+        versionName "1.0.0-beta-5"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -119,11 +119,6 @@ publishing {
                 coreDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
                 coreDependencyNode.appendNode('artifactId', 'core')
                 coreDependencyNode.appendNode('version', mavenCoreVersion)
-
-                def edgeDependencyNode = dependenciesNode.appendNode('dependency')
-                edgeDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
-                edgeDependencyNode.appendNode('artifactId', 'edge')
-                edgeDependencyNode.appendNode('version', mavenEdgeVersion)
             }
         }
         aarSnapshot(MavenPublication) {
@@ -161,11 +156,6 @@ publishing {
                 coreDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
                 coreDependencyNode.appendNode('artifactId', 'core')
                 coreDependencyNode.appendNode('version', mavenCoreVersion + '-SNAPSHOT')
-
-                def edgeDependencyNode = dependenciesNode.appendNode('dependency')
-                edgeDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
-                edgeDependencyNode.appendNode('artifactId', 'edge')
-                edgeDependencyNode.appendNode('version', mavenEdgeVersion + '-SNAPSHOT')
             }
         }
     }
@@ -216,7 +206,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
     testImplementation 'org.json:json:20180130'
-    implementation 'com.adobe.marketing.mobile:edge:1.0.0-beta-1'
+    testImplementation "com.adobe.marketing.mobile:edge:1.0.0"
 }
 
 afterEvaluate {

--- a/code/analyticsedge/src/phone/java/com/adobe/marketing/mobile/AnalyticsConstants.java
+++ b/code/analyticsedge/src/phone/java/com/adobe/marketing/mobile/AnalyticsConstants.java
@@ -20,7 +20,7 @@ final class AnalyticsConstants {
     static final String LOG_TAG = "AnalyticsEdge";
     static final String EXTENSION_NAME = "com.adobe.module.analyticsedge";
     static final String FRIENDLY_NAME = "AnalyticsEdge";
-    static final String EXTENSION_VERSION = "1.0.0-beta-2";
+    static final String EXTENSION_VERSION = "1.0.0-beta-5";
     static final String DATASTORE_NAME = EXTENSION_NAME;
 
     static final String APP_STATE_FOREGROUND = "foreground";
@@ -41,6 +41,10 @@ final class AnalyticsConstants {
 
     static final class Configuration {
         static final String GLOBAL_CONFIG_PRIVACY = "global.privacy";
+    }
+
+    static final class Edge {
+        static final String EVENT_TYPE = "com.adobe.eventType.edge";
     }
 
     static final class AnalyticsRequestKeys {

--- a/code/analyticsedge/src/phone/java/com/adobe/marketing/mobile/AnalyticsExtension.java
+++ b/code/analyticsedge/src/phone/java/com/adobe/marketing/mobile/AnalyticsExtension.java
@@ -206,7 +206,10 @@ class AnalyticsExtension extends Extension implements EventsHandler {
      */
     private MobilePrivacyStatus getPrivacyStatus() {
         if(currentConfiguration != null && !currentConfiguration.isEmpty()) {
-            return MobilePrivacyStatus.fromString(currentConfiguration.get(AnalyticsConstants.Configuration.GLOBAL_CONFIG_PRIVACY).toString());
+            final Object currentPrivacy = currentConfiguration.get(AnalyticsConstants.Configuration.GLOBAL_CONFIG_PRIVACY);
+            if(currentPrivacy != null) {
+                return MobilePrivacyStatus.fromString(currentPrivacy.toString());
+            }
         }
         return AnalyticsConstants.DEFAULT_PRIVACY_STATUS;
     }
@@ -408,8 +411,8 @@ class AnalyticsExtension extends Extension implements EventsHandler {
         eventData.put(AnalyticsConstants.XDMDataKeys.DATA, edgeEventData);
         final Event event = new Event.Builder(
                 AnalyticsConstants.ANALYTICS_XDM_EVENTNAME,
-                EdgeConstants.EVENT_TYPE_EDGE,
-                EdgeConstants.EVENT_SOURCE_EXTENSION_REQUEST_CONTENT).setEventData(eventData).build();
+                EventType.get(AnalyticsConstants.Edge.EVENT_TYPE),
+                EventSource.REQUEST_CONTENT).setEventData(eventData).build();
 
         MobileCore.dispatchEvent(event, null);
     }

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -21,7 +21,7 @@ artifactoryPassword=xxx
 moduleProjectName=analyticsedge
 moduleName=analyticsedge
 moduleAARName=analyticsedge-phone-release.aar
-moduleVersion=1.0.0-beta-2
+moduleVersion=1.0.0-beta-5
 
 mavenRepoName=AdobeMobileAnalyticsEdgeSdk
 mavenRepoDescription=Adobe Experience Platform Analytics Edge extension for the Adobe Experience Platform Mobile SDK
@@ -29,4 +29,3 @@ mavenUploadDryRunFlag=false
 
 # production versions for production build
 mavenCoreVersion=1.5.7
-mavenEdgeVersion=1.0.0-beta-1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes have been released as analyticsedge 1.0.0-beta5
## Description
- changed edge extension dependency to testImplementation for analytics edge extension as its needed for the tests only.
- fixed a null exception if a null privacy status is added to the config. added a test as well: test_handleAnalyticsTrackEvent_WhenPrivacyStatusIsNull
- updated the edge extension used to the released 1.0.0 build
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
